### PR TITLE
Windows: add eccodes paths to test environment if they exist

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,15 +40,25 @@ ecbuild_add_test( TARGET basic_fortran_static
                   ENVIRONMENT MAGPLUS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/..
                   LINKER_LANGUAGE Fortran )
 
+set( bufr_python_environment PYTHONPATH=${MAG_PYTHON_PATH}
+                             LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
+                             DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
+                             MAGPLUS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/.. )
+
+if( (EC_OS_NAME MATCHES "windows") AND (NOT "$ENV{ECCODES_SAMPLES_PATH}" MATCHES ""))
+    list( APPEND bufr_python_environment ECCODES_SAMPLES_PATH=$ENV{ECCODES_SAMPLES_PATH} )
+endif()
+
+if( (EC_OS_NAME MATCHES "windows") AND (NOT "$ENV{ECCODES_DEFINITIONS_PATH}" MATCHES ""))
+    list( APPEND bufr_python_environment ECCODES_DEFINITIONS_PATH=$ENV{ECCODES_DEFINITIONS_PATH} )
+endif()
+
 ecbuild_add_test( TARGET bufr_python
                   TYPE PYTHON
                   CONDITION HAVE_BUFR AND HAVE_PYTHON
                   ARGS bufr.py
                   RESOURCES bufr.py synop.bufr
-                  ENVIRONMENT PYTHONPATH=${MAG_PYTHON_PATH}
-                              LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
-                              DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
-                              MAGPLUS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/.. )
+                  ENVIRONMENT ${bufr_python_environment} )
 
 ecbuild_add_test( TARGET bufr_fortran
                   SOURCES   bufr.f90


### PR DESCRIPTION
We're having a problem when trying to build Magics on conda-forge. We rely on a conda-installed ecCodes binary, which means our ECCODES_SAMPLE_PATH and ECCODES_DEFINITIONS_PATH rely on environment variables (the defaults are broken on Windows) which are set automatically when activating the conda environment.

The problem is that these environment variables aren't being passed to ctest, so the bufr_python test fails on conda-forge:
https://ci.appveyor.com/project/conda-forge/magics-feedstock/builds/21855890?fullLog=true
```
[00:32:45] 4: Test command: C:\bld\magics_1548327453238\_h_env\python.exe "bufr.py"
[00:32:45] 4: Environment variables: 
[00:32:45] 4:  PYTHONPATH=C:/bld/magics_1548327453238/work/build/python
[00:32:45] 4:  LD_LIBRARY_PATH=C:/bld/magics_1548327453238/work/build/lib
[00:32:45] 4:  DYLD_LIBRARY_PATH=C:/bld/magics_1548327453238/work/build/lib
[00:32:45] 4:  MAGPLUS_HOME=C:/bld/magics_1548327453238/work/test/..
[00:32:45] 4:  OMP_NUM_THREADS=1
[00:32:45] 4: Test timeout computed to be: 1500
[00:32:45] 4: plot
[00:32:45] 4: Magics :------------------------------------------------------------------
[00:32:45] 4: Magics :
[00:32:45] 4: Magics :			  Magics 3.4.0.3
[00:32:45] 4: Magics :
[00:32:45] 4: Magics : Meteorological Applications Graphics Integrated Colour System
[00:32:45] 4: Magics :
[00:32:45] 4: Magics :			    Developed By
[00:32:45] 4: Magics :
[00:32:45] 4: Magics :   The European Centre for Medium-Range Weather Forecasts
[00:32:45] 4: Magics :
[00:32:45] 4: Magics :
[00:32:45] 4: Magics :------------------------------------------------------------------
[00:32:45] 4: ECCODES ERROR   :  Unable to find boot.def. Context path=C:/bld/eccodes_1548280617376/_h_env/Library/share/eccodes/definitions
[00:32:45] 4: 
[00:32:45] 4: Possible causes:
[00:32:45] 4: - The software is not correctly installed
[00:32:45] 4: - The environment variable ECCODES_DEFINITION_PATH is defined but incorrect
[00:32:45] 4: 
[00:32:45] 4: ecCodes assertion failed: `0' in C:\bld\eccodes_1548280617376\work\src\grib_context.c:205
```

I haven't been able to find an easier way of passing these two environment variables to ctest. If there is one, let me know!