### PR TITLE
Enable Windows build with Proj4 v6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ init:
   # auto-yes for conda
   - cmd: conda config --set always_yes yes
   # update conda
-  - cmd: conda update -n base -c defaults conda
+  - cmd: conda update -n base -c conda-forge conda
 
 clone_folder: $(MAGICS_SRC)
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ install:
 
   # install conda deps
   - cmd: conda install boost libnetcdf expat jinja2 xarray scipy cftime
-  - cmd: conda install -c conda-forge cmake jom proj4=5 pthreads-win32 libiconv eccodes pytest
+  - cmd: conda install -c conda-forge cmake jom proj4 pthreads-win32 libiconv eccodes pytest
 
   # gtk+ - needed for pango
   # includes cairo, pango, glib, and other deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
       env:
         MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
         PROJ4_PATH=~/miniconda3
-         
-    - os: osx 
+
+    - os: osx
       osx_image: xcode10.1
       addons:
         homebrew:
@@ -70,7 +70,7 @@ install:
   - git clone --depth 1 https://github.com/ecmwf/magics-python.git ${MAGICS_PYTHON_SRC}
   # install conda deps
   - conda install boost libnetcdf expat jinja2 xarray scipy cftime
-  - conda install -c conda-forge proj4=5 eccodes pytest
+  - conda install -c conda-forge proj4 eccodes pytest
   # search for conda-installed libraries
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   # auto-yes for conda
   - conda config --set always_yes yes
   # update conda
-  - conda update -n base -c defaults conda
+  - conda update -n base -c conda-forge conda
   # add extra conda dirs to path so cmake can find packages
   - export PATH=~/miniconda3/lib:~/miniconda3/include:${PATH}
 

--- a/src/common/MatrixHandler.h
+++ b/src/common/MatrixHandler.h
@@ -473,6 +473,11 @@ public:
 protected:
 };
 
+#include "magics_windef.h"
+#ifdef MAGICS_ON_WINDOWS
+#define PROJ_MSVC_DLL_IMPORT 1
+#endif
+
 #define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
 #include <proj_api.h>
 

--- a/src/common/Proj4Projection.h
+++ b/src/common/Proj4Projection.h
@@ -22,6 +22,12 @@
 #include <Proj4ProjectionAttributes.h>
 #include <Transformation.h>
 #include <XmlNode.h>
+
+#include "magics_windef.h"
+#ifdef MAGICS_ON_WINDOWS
+#define PROJ_MSVC_DLL_IMPORT 1
+#endif
+
 #define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
 #include <proj_api.h>
 

--- a/src/decoders/GeoPointsDecoder.h
+++ b/src/decoders/GeoPointsDecoder.h
@@ -24,6 +24,11 @@
 
 #include "magics.h"
 
+#include "magics_windef.h"
+#ifdef MAGICS_ON_WINDOWS
+#define PROJ_MSVC_DLL_IMPORT 1
+#endif
+
 #define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
 #include <proj_api.h>
 #include "Data.h"

--- a/src/decoders/NetcdfGeoMatrixInterpretor.h
+++ b/src/decoders/NetcdfGeoMatrixInterpretor.h
@@ -24,6 +24,11 @@
 
 #include "magics.h"
 
+#include "magics_windef.h"
+#ifdef MAGICS_ON_WINDOWS
+#define PROJ_MSVC_DLL_IMPORT 1
+#endif
+
 #define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
 #include <proj_api.h>
 #include "Matrix.h"


### PR DESCRIPTION
There were a couple of patches which I needed to add to get the magics-feedstock to build on Windows (see https://github.com/conda-forge/magics-feedstock/pull/35). One is already merged into ecBuild.

This PR defines PROJ_MSVC_DLL_IMPORT so we can import proj_api.h without getting 'unresolved external symbol' errors.

We also update the CI to build with proj4 v6.