### PR TITLE
Use magics-python master for testing python interface

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,7 +52,7 @@ install:
   - cmd: git clone --depth 1 https://github.com/ecmwf/ecbuild.git %ECBUILD_SRC%
 
   # install magics-python src
-  - cmd: git clone -b develop --depth 1 https://github.com/ecmwf/magics-python.git %MAGICS_PYTHON_SRC%
+  - cmd: git clone -b master --depth 1 https://github.com/ecmwf/magics-python.git %MAGICS_PYTHON_SRC%
 
   # install linux utils
   - cmd: conda install -c msys2 m2-bash ^

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
     - os: osx
       osx_image: xcode10.1
-      addons: 
+      addons:
         homebrew:
           packages:
             - pango
@@ -70,8 +70,8 @@ install:
   # install ecbuild
   - git clone --depth 1 https://github.com/ecmwf/ecbuild.git ${ECBUILD_SRC}
   # install magics-python source
-  - git clone -b develop --depth 1 https://github.com/ecmwf/magics-python.git ${MAGICS_PYTHON_SRC}
-  
+  - git clone -b master --depth 1 https://github.com/ecmwf/magics-python.git ${MAGICS_PYTHON_SRC}
+
   # install conda deps
   - conda install boost libnetcdf expat jinja2 xarray scipy cftime
   - conda install -c conda-forge proj4=5 eccodes pytest cairo pango pip


### PR DESCRIPTION
CI has been using magics-python develop branch for testing which is now 7 months out of date. This PR switches to master branch instead.

There also appear to be some commits in master which are not in develop so I've merged them. Would appreciate a second pair of eyes on this one please @sylvielamythepaut @StephanSiemen 