### PR TITLE
Export `version` symbol to Python API again

### DIFF
--- a/src/api/MagicsCallsPython.cc
+++ b/src/api/MagicsCallsPython.cc
@@ -102,6 +102,10 @@ MAGICS_EXPORT const char* home() {
     return MagicsCalls::home();
 }
 
+MAGICS_EXPORT const char* version() {
+    return MagicsCalls::version();
+}
+
 #define PYTHON_VOID(NAME) \
     MAGICS_EXPORT const char* py_##NAME() { return python_void(#NAME, MagicsCalls::NAME); }
 


### PR DESCRIPTION
Hi there,

first things first: Thanks a stack for conceiving and maintaining this excellent software.

While working on the [GribMagic] program, which uses the `Magics` Python bindings to `libMagPlus`, we discovered that the `version` symbol somehow stopped being exported starting with libMagPlus 4.7.0. We reported about our observations in detail at https://github.com/ecmwf/magics-python/issues/39.

So, when accessing `dll.version` from Python, it croaked like
```python
AttributeError: dlsym(0x7f7f59e05120, version): symbol not found
```

In turn, this also made _selfcheck_'s report slightly bogus:
```
$ python -m Magics selfcheck
Found: Magics 'You are using an old version of magics ( < 4.0.0)'.
Your system is ready.
```

With this small patch, everything is in order again:
```
$ python -m Magics selfcheck
Found: Magics 'Magics 4.9.3'.
Your system is ready.
```

```python
>>> import Magics.macro
>>> Magics.macro.version()
'Magics 4.9.3'
```

With kind regards,
Andreas.

[GribMagic]: https://github.com/earthobservations/gribmagic
