### PR TITLE
Fix empty vector access errors when _GLIBCXX_ASSERTIONS is set (SD-80581)

### DIFF
--- a/src/decoders/GribRegularInterpretor.cc
+++ b/src/decoders/GribRegularInterpretor.cc
@@ -566,6 +566,7 @@ void GribRegularInterpretor::interpretAsMatrix(GribDecoder& grib) const {
 
         if (jPointsAreConsecutive) {
             vector<double>* d = new vector<double>(nb);  // temporary array
+            d->resize(nb);
             double* d1        = &d->front();             // temporary array pointer
             double* d2        = &u->front();             // final array
 
@@ -581,12 +582,14 @@ void GribRegularInterpretor::interpretAsMatrix(GribDecoder& grib) const {
         else  // otherwise, just copy the array of values as they are
         {
             if (v != NULL) {
+                v->resize(nb);
                 grib_get_double_array(grib.uHandle(), "values", &u->front(), &aux);
                 grib_get_double_array(grib.uHandle(), "values", &u->data_.front(), &aux);
                 grib_get_double_array(grib.vHandle(), "values", &v->front(), &aux);
                 grib_get_double_array(grib.vHandle(), "values", &v->data_.front(), &aux);
                 if (c) {
                     c->data_.resize(nb);
+                    c->resize(nb);
                     grib_get_double_array(grib.cHandle(), "values", &c->front(), &aux);
                     grib_get_double_array(grib.cHandle(), "values", &c->data_.front(), &aux);
                 }
@@ -1546,6 +1549,7 @@ void GribRotatedInterpretor::interpretAsMatrix(GribDecoder& grib) const {
         else  // otherwise, just copy the array of values as they are
         {
             if (v != NULL) {
+                v->resize(aux);
                 grib_get_double_array(grib.uHandle(), "values", &u->front(), &aux);
                 grib_get_double_array(grib.uHandle(), "values", &u->data_.front(), &aux);
                 grib_get_double_array(grib.vHandle(), "values", &v->front(), &aux);

--- a/src/visualisers/IsoPlot.cc
+++ b/src/visualisers/IsoPlot.cc
@@ -1677,7 +1677,7 @@ CellArray::CellArray(MatrixHandler& data, IntervalMap<int>& range, const Transfo
         double missing = data.missing();
 
 
-        int i = 0;
+        auto i = points_.begin();
 
         MagLog::dev() << "min = " << data.min() << "  max = " << data.max() << endl;
         for (vector<std::pair<double, double> >::iterator xy = xypoints.begin(); xy != xypoints.end(); ++xy) {
@@ -1701,7 +1701,7 @@ CellArray::CellArray(MatrixHandler& data, IntervalMap<int>& range, const Transfo
             else {
                 // cout << "MISSING VALUE-->" << geo->second << ", " << geo->first << endl;
             }
-            points_[i] = value;
+            points_.insert(i, value);
             i++;
             ++geo;
         }


### PR DESCRIPTION
When `_GLIBCXX_ASSERTIONS` is set (see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html), Magics sometimes throws a runtime error:

```
/usr/include/c++/12/bits/stl_vector.h:1123: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = double; _Alloc = std::allocator<double>; reference = double&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

The runtime error are raised when some instance methods are invoked on an empty vector, e.g. `operator[]` or `front()`. This PR tries to fix some of these potential errors, resizing the vector before populating it or using `insert` instead of `operator[]`.


See https://jira.ecmwf.int/plugins/servlet/desk/portal/4/SD-80581 for more details.