### PR TITLE
Fix geopotential plotting on upper air charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build
 .ipynb_checkpoints
 
 .vscode
+.vscode/
 *.sublime-workspace
 notebook/.ipynb_checkpoints
 compile_commands.json
@@ -41,6 +42,7 @@ tmp.*
 *.ppm
 .env
 *.swp
+
 
 # mac
 .DS_Store

--- a/share/magics/bufr_98.xml
+++ b/share/magics/bufr_98.xml
@@ -103,6 +103,8 @@
   <type value='2'>
 	<subtype value='91'>pilot</subtype>
 	<subtype value='101' template='temp'>temp</subtype>
+    <subtype value='109' template='temp'>temp</subtype>
+    <subtype value='111' template='temp'>temp</subtype>
   </type>
 
   <type value='4'>

--- a/share/magics/obs.xml
+++ b/share/magics/obs.xml
@@ -106,12 +106,12 @@
 	<obs_identification row='-1' column='-1'/>
  </obs_template>
 
- <obs_template type='temp' rows='4' columns='5'>:
+ <obs_template type='temp' rows='4' columns='6'>:
 	<obs_station_ring row='0' column='0'/>
 	<obs_wind/>
 	<obs_temperature row='1' column='-1'/>
 	<obs_dewpoint row='-1' column='-1'/>
-	<obs_height row='1' column='1'/>
+	<obs_height row='1' column='4'/>
 	<obs_thickness row='0' column='1' justification='left'/>
 	<obs_time_plot row='0' column='-1' />
 	<obs_identification row='-2' column='-1'/>


### PR DESCRIPTION
This PR fixes the issue when the geopotential value did not appear on upper air BUFR charts.

TODO:

- check if the changes do not cause problems in other BUFR plot types
- the default station ring style does not look right: 
![image](https://github.com/user-attachments/assets/b2950955-d098-4b7a-a594-0076d941c938)
