### PR TITLE
Adjust the test data path for Nexus migration

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -48,7 +48,7 @@ function( add_magics_test )
 	foreach( data ${_p_DATA} )
         string( REGEX REPLACE "[^A-Za-z0-9_]" "_" target "${_p_NAME}_data_${data}" )
         ecbuild_get_test_data( NAME ${data} TARGET ${target} NOCHECK 
-            DIRNAME magics/regression/${where})
+            DIRNAME magics/test-data/regression/${where})
         list( APPEND targets  "${target}")
 	endforeach()
 
@@ -74,7 +74,7 @@ function( add_magics_test )
         	list( APPEND targets "${target}")
 	    
 			ecbuild_get_test_data( NAME ${todo} NOCHECK 
-				DIRNAME magics/reference/${version}/${where} )
+				DIRNAME magics/test-data/reference/${version}/${where} )
 		endforeach()
 	
 		set( versions "${versions}${version} " )


### PR DESCRIPTION
### Description

Adjust the test data path for Nexus migration. Instead of using https://get.ecmwf.int/repository/test-data/*project*/, the project will now access the data at https://sites.ecmwf.int/repository/*project*/test-data/.

This change also implies the use of the latest ecbuild, with the necessary adjustments to `ecbuild_get_test_data/multidata` functions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 