### PR TITLE
Fix missing stdint.h header breaking build on GCC 15

### DIFF
--- a/src/common/ObjectParser.cc
+++ b/src/common/ObjectParser.cc
@@ -19,6 +19,7 @@
 #include "ObjectParser.h"
 #include "Translator.h"
 #include "Value.h"
+#include <stdint.h>
 
 namespace magics {
 

--- a/src/magics.h
+++ b/src/magics.h
@@ -95,6 +95,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <stdint.h>
 
 using std::cerr;
 using std::cout;
@@ -376,9 +377,9 @@ inline MAGICS_NO_EXPORT string buildSharePath(const string& config, const string
             found = libpath.find_last_of("/\\");
             magplushome = libpath.substr(0,found);
        }
-       else 
+       else
 #endif
-         magplushome = string(MAGICS_INSTALL_PATH);  
+         magplushome = string(MAGICS_INSTALL_PATH);
     }
     ostringstream out;
     out << magplushome << "/share/magics/" << config;


### PR DESCRIPTION
### Description

Adding stdint.h headers to prevent uint32_t and uint8_t not defined errors on gcc 15.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 