### PR TITLE
ci: migrate ecmwf-actions references to ecmwf

### DIFF
--- a/.github/workflows/legacy-ci.yml
+++ b/.github/workflows/legacy-ci.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Build & Test
       id: build-test
-      uses: ecmwf-actions/build-package@v2
+      uses: ecmwf/build-package@v2
       with:
         self_coverage: true
         dependencies: |
@@ -126,7 +126,7 @@ jobs:
     if: always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
     steps:
     - name: Notify Teams
-      uses: ecmwf-actions/notify-teams@v1
+      uses: ecmwf/notify-teams@v1
       with:
         incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
         needs_context: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
The `ecmwf-actions` GitHub organization has been merged into `ecmwf`.
This PR updates workflow `uses:` directives from `ecmwf-actions/` to `ecmwf/`.

No functional changes - the actions are identical, just relocated.

---
*This PR was created automatically.*
